### PR TITLE
Fix for aarch64 image builds and rename 'mkimage-dnf.sh' to 'mkimage.sh'

### DIFF
--- a/6/Dockerfile
+++ b/6/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile to create Mageia linux 6 base images
-# Create base image with mkimage-dnf.sh script
+# Create base image with mkimage.sh script
 #
 
 FROM scratch

--- a/README.md
+++ b/README.md
@@ -7,8 +7,7 @@ http://www.mageia.org
 
 ## Build Instructions
 
-  * If building mageia images >= 6, use _mkimage-dnf.sh_
-  * If building mageia images < 6, use _mkimage-urpmi.sh_
+  * Use _mkimage.sh_
 
 ## How to run the images
 

--- a/mkimage.sh
+++ b/mkimage.sh
@@ -14,7 +14,7 @@ set -e
 mkimg="$(basename "$0")"
 
 usage() {
-	echo >&2 "usage: $mkimg --rootfs=rootfs_path --version=mageia_version [--mirror=url] [--package-manager=(dnf|microdnf|urpmi)] [--forcearch=ARCH] [--with-systemd]"
+	echo >&2 "usage: $mkimg --rootfs=rootfs_path --version=mageia_version [--mirror=url] [--package-manager=(dnf|microdnf|urpmi)] [--forcearch=ARCH] [--with-systemd] [--quiet]"
 	echo >&2 "   ie: $mkimg --rootfs=. --version=6 --with-systemd"
 	echo >&2 "       $mkimg --rootfs=. --version=cauldron --package-manager=dnf --with-systemd"
 	echo >&2 "       $mkimg --rootfs=/tmp/rootfs --version=6 --mirror=http://mirrors.kernel.org/mageia/distrib/6/x86_64/ --with-systemd"
@@ -23,7 +23,7 @@ usage() {
 	exit 1
 }
 
-optTemp=$(getopt --options '+d,v:,p:,a:,s,h' --longoptions 'rootfs:,version:,mirror:,package-manager:,forcearch:,with-systemd, help' --name $mkimg -- "$@")
+optTemp=$(getopt --options '+d,v:,p:,a:,s,q,h' --longoptions 'rootfs:,version:,mirror:,package-manager:,forcearch:,with-systemd,quiet,help' --name $mkimg -- "$@")
 eval set -- "$optTemp"
 unset optTemp
 
@@ -38,6 +38,7 @@ while true; do
                 -p|--package-manager) pkgmgr="$2" ; shift 2 ;;
                 -a|--forcearch) buildarch="$2" ; shift 2 ;;
                 -s|--with-systemd) systemd=true ; shift ;;
+                -q|--quiet) quiet=true ; shift ;;
                 -h|--help) usage ;;
                  --) shift ; break ;;
         esac
@@ -139,7 +140,7 @@ fi
             --installroot="$rootfsDir" \
             --releasever="$releasever" \
             --setopt=install_weak_deps=False \
-            --nodocs --assumeyes --quiet \
+            --nodocs --assumeyes ${quiet: --quiet} \
             install basesystem-minimal $pkgmgr locales locales-en $systemd
 )
 

--- a/mkimage.sh
+++ b/mkimage.sh
@@ -126,11 +126,18 @@ if [ -z $pkgmgr ]; then
         pkgmgr="dnf urpmi"
 fi
 
+extrapkgs=""
+# If urpmi is included, we *must* add curl to the target environment,
+# since aria2 segfaults on some architectures, like aarch64
+if [[ $pkgmgr == *"urpmi"* ]]; then
+        extrapkgs="$extrapkgs curl"
+fi
+
 if [ ! -z $systemd ]; then
         echo -e "--------------------------------------"
         echo -e "Creating image with systemd support."
         echo -e "--------------------------------------\n"
-        systemd="systemd"
+        extrapkgs="$extrapkgs systemd"
 fi
 
 (
@@ -141,15 +148,23 @@ fi
             --releasever="$releasever" \
             --setopt=install_weak_deps=False \
             --nodocs --assumeyes ${quiet: --quiet} \
-            install basesystem-minimal $pkgmgr locales locales-en $systemd
+            install basesystem-minimal $pkgmgr locales locales-en $extrapkgs
 )
 
+# Make sure /etc/resolv.conf has something useful in it
+# This is being done before urpmi.addmedia call to ensure
+# that will work from within the chroot...
+mkdir -p "$rootfsDir/etc"
+cat > "$rootfsDir/etc/resolv.conf" <<'EOF'
+nameserver 8.8.8.8
+nameserver 8.8.4.4
+EOF
+
 # Configure urpmi mirrorlist if urpmi is included on the system
+# We do this in within the root to minimize impact from host,
+# and so that target system architectures can be properly configured
 if [[ $pkgmgr == *"urpmi"* ]]; then
-        if [ -x /usr/sbin/urpmi.addmedia ]; then
-                urpmi.addmedia --distrib --mirrorlist "https://mirrors.mageia.org/api/mageia.$releasever.$buildarch.list" \
-                               --urpmi-root "$rootfsDir"
-        fi
+        chroot "$rootfsDir" urpmi.addmedia --curl --distrib --mirrorlist "https://mirrors.mageia.org/api/mageia.$releasever.$buildarch.list"
 fi
 
 "$(dirname "$BASH_SOURCE")/.febootstrap-minimize" "$rootfsDir"
@@ -175,13 +190,6 @@ fi
 # Docker mounts tmpfs at /dev and procfs at /proc so we can remove them
 rm -rf "$rootfsDir/dev" "$rootfsDir/proc"
 mkdir -p "$rootfsDir/dev" "$rootfsDir/proc"
-
-# make sure /etc/resolv.conf has something useful in it
-mkdir -p "$rootfsDir/etc"
-cat > "$rootfsDir/etc/resolv.conf" <<'EOF'
-nameserver 8.8.8.8
-nameserver 8.8.4.4
-EOF
 
 if [ ! -z $systemd ]; then
     tarFile="$dir/rootfs-systemd.tar.xz"

--- a/mkimage.sh
+++ b/mkimage.sh
@@ -7,7 +7,6 @@
 #
 # Tested working versions are for Mageia 6 onwards (inc. cauldron).
 #
-# Based on mkimage-urpmi.sh
 #
 
 set -e


### PR DESCRIPTION
This PR contains the changes needed to be able to successfully build the default configuration for Mageia 7/Cauldron AArch64 images from a Mageia 6 host.

Moreover, some trivial cleanups have been added as well.

Relates to #12 