### PR TITLE
Skip restarting systemd-binfmt.service when unnecessary

### DIFF
--- a/mkimage.sh
+++ b/mkimage.sh
@@ -71,13 +71,15 @@ if [ ! -z $buildarch ]; then
 	# Determine if the arch is not native...
 	rpmbuildarch="$(rpm --eval '%{_target_cpu}')"
 	if [ "$rpmbuildarch" != "$buildarch" ]; then
-		# Check for the existance of qemu-user-static
-		if ! rpm --quiet --query qemu-user-static; then
-			echo "Error: 'qemu-user-static' needs to be installed for non-native rootfs builds!"
-			exit 1
-		fi
-		# To ensure qemu-user-static can be used, restart systemd-binfmt
-		systemctl restart systemd-binfmt.service
+        if ! ls /proc/sys/fs/binfmt_misc/qemu* >/dev/null 2>&1; then
+            # Check for the existance of qemu-user-static
+            if ! rpm --quiet --query qemu-user-static; then
+                echo "Error: 'qemu-user-static' needs to be installed for non-native rootfs builds!"
+                exit 1
+            fi
+            # To ensure qemu-user-static can be used, restart systemd-binfmt
+            systemctl restart systemd-binfmt.service
+        fi
 	fi
 fi
 


### PR DESCRIPTION
The script shouldn't be altering the system when it's not necessary,
plus this allows it to work in situations where qemu is installed by
other means.