### PR TITLE
New official images repo update method.

### DIFF
--- a/build2release/build2release.sh
+++ b/build2release/build2release.sh
@@ -20,7 +20,7 @@ _traperr() {
 # to make a brand new one that doesn't contain that older tarball commit
 
 # This script version
-VERSION=0.6.7
+VERSION=0.6.9
 
 BUILD=0
 PUSH=0

--- a/build2release/build2release.sh
+++ b/build2release/build2release.sh
@@ -85,7 +85,7 @@ fi
 
 # Update official docker library
 if [[ ${UPDATE_OFFICIAL} -eq 1 ]]; then
-  update_library
+  new_update_library
 fi
 
 # Cleanup after new images ar built and pushed

--- a/build2release/functions.sh
+++ b/build2release/functions.sh
@@ -128,6 +128,58 @@ function build_image() {
   done
 }
 
+function new_update_library() {
+  local commit_msg="Update mageia images"
+
+  # Now clone docker official-images repo and update the library image
+  print_msg "* Cloning ${OFFICIAL_IMAGES_REPO_URL}"
+  cd ${BUILD_DIR}/build
+  run_command git clone ${OFFICIAL_IMAGES_REPO_URL}
+  repo_dir=$(echo ${OFFICIAL_IMAGES_FORK}|cut -d'/' -f2)
+  cd ${repo_dir}
+
+  # Update official-images fork with latest remote changes before working on it
+  print_msg "[+] Adding new remote pointing to our fork: ${OFFICIAL_IMAGES_FORK}"
+  run_command git remote add fork ${OFFICIAL_IMAGES_FORK}
+  print_msg "[+] Checking out to new branch: update"
+  # Create a new branch to work on it
+  run_command git checkout -b update
+
+  # Get the last commit hash of dist branch
+  print_msg "[+] Get last commit from ${MGA_BREW_REPO}"
+  git_commit=$(git ls-remote ${MGA_BREW_REPO_URL} refs/heads/dist | cut -f 1)
+  [ $? -gt 0 ] && echo "ERROR: Cannot get last commit from dist branch." && exit 1
+  print_msg "[+] Last commit is: ${git_commit}"
+
+  # Update library file with new hash
+  print_msg "[+] Updating library file with new commit"
+  if [ "${git_commit}" != "" ]; then
+    sed -i -r "s/(GitCommit: *).*/\1${git_commit}/" library/mageia
+    [ $? -gt 0 ] && echo "ERROR: Cannot update commit hash on library file." && exit 1
+  else
+    echo "ERROR: Git commit is empty !!" && exit 1
+  fi
+
+  # Update image tags for all versions declared on MGA_SUPPORTED_VERSION_TAGS
+  for mga_version in "${!MGA_SUPPORTED_VERSION_TAGS[@]}"; do
+    version_tags="${MGA_SUPPORTED_VERSION_TAGS[${mga_version}]}"
+    print_msg "* Updating tags for image version ${mga_version}: ${version_tags}"
+    if [ "${version_tags}" != "" ]; then
+      sed -i -r "s/(Tags: ${mga_version},*).*/Tags: ${version_tags}/" library/mageia
+      [ $? -gt 0 ] && echo "ERROR: Cannot update tags for image version ${mga_version} on library file." && exit 1
+    fi
+  done
+
+  # Add and commit change
+  run_command git add library/mageia
+  [ $? -gt 0 ] && echo "ERROR: Cannot git add modified library file." && exit 1
+  run_command git commit -m \"${commit_msg}\"
+  [ $? -gt 0 ] && echo "ERROR: Cannot commit on library file." && exit 1
+  print_msg "[+] Pushing changes to fork"
+  run_command git push --set-upstream fork update
+  [ $? -gt 0 ] && echo "ERROR: Cannot push on library file." && exit 1
+}
+
 function update_library() {
   local commit_msg="Updated mageia images"
 

--- a/build2release/functions.sh
+++ b/build2release/functions.sh
@@ -18,7 +18,7 @@ OFFICIAL_IMAGES_FORK="juanluisbaptiste/official-images"
 OFFICIAL_IMAGES_FORK_URL="git@github.com:${OFFICIAL_IMAGES_FORK}"
 OFFICIAL_IMAGES_REPO="docker-library/official-images"
 OFFICIAL_IMAGES_REPO_URL="git@github.com:${OFFICIAL_IMAGES_REPO}"
-BRANCH="master"
+BRANCH="develop"
 # DATE=$(date +%m-%d-%Y_%H%M%S)
 BUILD_LOG_FILE="${PWD}/mga-build.out"
 

--- a/build2release/functions.sh
+++ b/build2release/functions.sh
@@ -18,6 +18,7 @@ OFFICIAL_IMAGES_FORK="juanluisbaptiste/official-images"
 OFFICIAL_IMAGES_FORK_URL="git@github.com:${OFFICIAL_IMAGES_FORK}"
 OFFICIAL_IMAGES_REPO="docker-library/official-images"
 OFFICIAL_IMAGES_REPO_URL="git@github.com:${OFFICIAL_IMAGES_REPO}"
+BRANCH="master"
 # DATE=$(date +%m-%d-%Y_%H%M%S)
 BUILD_LOG_FILE="${PWD}/mga-build.out"
 
@@ -117,8 +118,8 @@ function build_image() {
   print_msg "* Deleting dist branch..."
   run_command git branch -D dist ${GIT_OUTPUT}
 
-  print_msg "* Recreating dist branch..."
-  run_command git checkout ${GIT_OUTPUT} -b dist master
+  print_msg "* Recreating dist branch from [${BRANCH}] branch..."
+  run_command git checkout ${GIT_OUTPUT} -b dist ${BRANCH}
 
   # Build all archs for all versions declared on MGA_SUPPORTED_ARCHS
   for mga_version in "${!MGA_SUPPORTED_ARCHS[@]}"; do

--- a/build2release/functions.sh
+++ b/build2release/functions.sh
@@ -18,7 +18,7 @@ OFFICIAL_IMAGES_FORK="juanluisbaptiste/official-images"
 OFFICIAL_IMAGES_FORK_URL="git@github.com:${OFFICIAL_IMAGES_FORK}"
 OFFICIAL_IMAGES_REPO="docker-library/official-images"
 OFFICIAL_IMAGES_REPO_URL="git@github.com:${OFFICIAL_IMAGES_REPO}"
-BRANCH="develop"
+BRANCH="master"
 # DATE=$(date +%m-%d-%Y_%H%M%S)
 BUILD_LOG_FILE="${PWD}/mga-build.out"
 

--- a/build2release/functions.sh
+++ b/build2release/functions.sh
@@ -93,6 +93,10 @@ function push () {
   print_msg " [-] Commit new rootfs file to dist branch..."
   run_command git commit -m \"${commit_msg}\"
 
+  # Obtain the commit ID
+  commit_id=$(git rev-parse HEAD)
+  print_msg " [-] Commit ID: ${commit_id}"
+
   # Force push new dist branch
   print_msg " [-] Force-pushing new dist branch..."
   run_command git push -f origin dist


### PR DESCRIPTION
New official images repo update method:

```
git clone git@github.com:docker-library/official-images.git # note this is the upstream, not the fork!
cd official-images
git remote add fork git@github.com:juanluisbaptiste/official-images.git
git checkout -b update # new branch - you can pick any name that suits you
# change library/mageia here
git commit
git push --set-upstream fork update # this will push the branch as a new branch on your fork, but built from the latest upstream code; the first push here will also print out a handy URL for opening the PR

```